### PR TITLE
Add loader component and integrate with artists fetch

### DIFF
--- a/src/css/loader.css
+++ b/src/css/loader.css
@@ -1,0 +1,35 @@
+.loader {
+  width: 48px;
+  height: 48px;
+  display: inline-block;
+  margin: 0 auto;
+  position: relative;
+  border: 3px solid;
+  border-color: #de3500 #0000 #fff #0000;
+  border-radius: 50%;
+  box-sizing: border-box;
+  animation: 1s rotate linear infinite;
+}
+.loader:before,
+.loader:after {
+  content: '';
+  top: 0;
+  left: 0;
+  position: absolute;
+  border: 10px solid transparent;
+  border-bottom-color: #fff;
+  transform: translate(-10px, 19px) rotate(-35deg);
+}
+.loader:after {
+  border-color: #de3500 #0000 #0000 #0000;
+  transform: translate(32px, 3px) rotate(-35deg);
+}
+@keyframes rotate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loader.hidden {
+  display: none;
+}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -3,6 +3,7 @@
 @import url('./base.css');
 @import url('./container.css');
 @import url('./animations.css');
+@import url('./loader.css');
 
 /* Sections style */
 @import url('./header.css');

--- a/src/js/handlers.js
+++ b/src/js/handlers.js
@@ -2,10 +2,16 @@ import iziToast from 'izitoast';
 import 'izitoast/dist/css/iziToast.min.css';
 import { fetchArtists } from './api';
 import { renderArtists } from './render-function';
+import { loader } from './helpers';
+import { refs } from './refs';
 
 export async function handleArtists() {
+  let loaderEl;
   try {
+    loaderEl = loader.create(refs.artistsList);
+    loader.show(loaderEl);
     const { data } = await fetchArtists();
+    loader.show(loaderEl);
     renderArtists(data.artists);
   } catch (error) {
     if (error.response) {
@@ -15,5 +21,7 @@ export async function handleArtists() {
     } else {
       iziToast.error({ message: `Error: ${error.message}` });
     }
+  } finally {
+    loader.hide(loaderEl);
   }
 }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -8,3 +8,31 @@ export const prepareArtistDescription = (text = '') => {
   }
   return text.length > 80 ? text.slice(0, 80).trim() + '...' : text;
 };
+
+export const loader = {
+  create(element) {
+    if (!element) return;
+    const markup = '<span class="loader hidden"></span>';
+    element.insertAdjacentHTML('beforeend', markup);
+    return element.querySelector('.loader');
+  },
+  show(loaderEl) {
+    loaderEl?.classList.remove('hidden');
+  },
+  hide(loaderEl) {
+    loaderEl?.classList.add('hidden');
+  },
+};
+
+/*
+ Інструкція:
+  - create(parentEl) → додає лоадер у вказаний контейнер і повертає його
+  - show(loaderEl) → показує лоадер (знімає клас 'hidden')
+  - hide(loaderEl) → ховає лоадер (додає клас 'hidden')
+
+ Використання:
+   const loaderEl = loader.create(refs.container);
+   loader.show(loaderEl);
+   ... // async code
+   loader.hide(loaderEl);
+*/

--- a/src/js/refs.js
+++ b/src/js/refs.js
@@ -1,3 +1,4 @@
 export const refs = {
   artistsList: document.querySelector('.artists-list'),
+  loader: document.querySelector('.loader'),
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,6 @@
 import { handleArtists } from './js/handlers';
+import { loader } from './js/helpers.js';
+import { refs } from './js/refs.js';
 import './js/to-top.js';
+
 handleArtists();

--- a/src/partials/artists.html
+++ b/src/partials/artists.html
@@ -1,9 +1,7 @@
 <section class="section-artists" id="section-artists">
   <div class="container">
     <h3 class="artists-title">Artists</h3>
-    <h2 class="artists-subtitle">
-      Explore Your New Favorite Artists
-    </h2>
+    <h2 class="artists-subtitle">Explore Your New Favorite Artists</h2>
     <ul class="artists-list"></ul>
   </div>
 </section>


### PR DESCRIPTION
Introduced a loader spinner with supporting CSS and helper functions. Updated the artists handler to show and hide the loader during async fetch operations. Adjusted imports and references to support the loader, and included the loader CSS in the main styles.